### PR TITLE
v.isNumeric only checks for integer not decimals

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -432,7 +432,7 @@ class Rules {
     }
 
     * numeric(field, value, message){
-        if(!v.isNumeric(value.toString())){
+        if(!v.isFloat(value.toString())){
             this.validator.addError(field, 'rule', 'numeric', message || 'The value entered is not numeric');
             return false;
         }


### PR DESCRIPTION
According to the documentation: The field under validation must be a numeric value. This could also include a numeric string or decimals

The regex used by the validator `/^[-+]?[0-9]+$/ ` does not check floating numbers.